### PR TITLE
[mobs_farlands] Add dependency 'wool'

### DIFF
--- a/mods/mobs_farlands/depends.txt
+++ b/mods/mobs_farlands/depends.txt
@@ -1,2 +1,3 @@
 default
 mobs
+wool


### PR DESCRIPTION
*dinosaurs.lua* makes use of *wool_orange.png* which is part of *wool* mod. Other dependencies listed in "depends.txt" (*default* & *mobs*) do not list *wool* as required dependency.